### PR TITLE
fix ownership for victor configuration files

### DIFF
--- a/Victor/dq2.victor.cms/config/dq2/etc/post_install.sh
+++ b/Victor/dq2.victor.cms/config/dq2/etc/post_install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+function changeOwner(){
+    [ ! -d $1  ] &&  mkdir -p $1 
+    chown -R $DASHBUSER $1 
+    echo 'chown for ' $1
+}
+# This is the user that will own the binaries
+DASHBUSER=${DASHBUSER:=cmspopdb}
+DASHB_NOTIFICATION=${DASHB_NOTIFICATION:=cms-popdb-alarms@cern.ch}
+
+echo "User that will run the service is $DASHBUSER"
+echo "EMAIL notification address is ${DASHB_NOTIFICATION}"
+
+#useradd --shell /bin/bash --create-home --home-dir /home/cern cern
+#/usr/sbin/useraddcern cmspopdb
+
+changeOwner /opt/dq2/etc/dq2.cfg
+changeOwner /opt/dq2/etc/logging.cfg

--- a/Victor/dq2.victor.cms/setup.cfg
+++ b/Victor/dq2.victor.cms/setup.cfg
@@ -12,6 +12,7 @@ plat-name       = noarch
 [bdist_rpm]
 dist-dir        = ./dist
 vendor          = "Fernando Harald Barreiro Megino <fernando.harald.barreiro.megino@cern.ch>"
+post-install    = config/dq2/etc/post_install.sh
 requires        = cx_Oracle >= 0.5.1
 		  oracle-instantclient-tnsnames.ora
                   python-simplejson


### PR DESCRIPTION
Hi all,

This pull request fixes issue #12 . It adds a post-install hook for the victor agent which changes the owner of the config files from root to cmspopdb. In this version only the ownership for the configuration files, not for the folder containing those files, is transfered. 

Please feel free to review and comment.
Thanks, Rene
