### PR TITLE
Adapted user to run cron-jobs for the victor agent

### DIFF
--- a/Victor/dq2.victor.cms/config/cron.d/victor.agent.cms
+++ b/Victor/dq2.victor.cms/config/cron.d/victor.agent.cms
@@ -15,7 +15,7 @@ MIME="MIME-Version: 1.0"
 CONTENTTYPE="Content-Type: text/html"
 CONTENTDISPO="Content-Disposition: inline"
 
-00 10 * * * root /usr/bin/python2.6 $EXECUTABLE  2>$ERRLOG ; STATUS=$?; [ $STATUS -ne 0 ] && ( echo ${SUBJECT_ERR}; echo $MIME; echo $CONTENTTYPE; echo  $CONTENTDISPO; echo -e "<pre>Problem running the application $EXECUTABLE on " `hostname` "\ncheck log file $LOG\n"; cat $ERRLOG; echo "</pre>") | /usr/sbin/sendmail $MAILTO ; [ $STATUS -eq 0 ] && ( echo ${SUBJECT_OK}; echo $MIME; echo $CONTENTTYPE; echo  $CONTENTDISPO;  echo -e "<pre>Finished running the application $EXECUTABLE on " `hostname` "\ncheck log file $LOG\n</pre>") | /usr/sbin/sendmail $MAILTO ;
+00 10 * * * cmspopdb /usr/bin/python2.6 $EXECUTABLE  2>$ERRLOG ; STATUS=$?; [ $STATUS -ne 0 ] && ( echo ${SUBJECT_ERR}; echo $MIME; echo $CONTENTTYPE; echo  $CONTENTDISPO; echo -e "<pre>Problem running the application $EXECUTABLE on " `hostname` "\ncheck log file $LOG\n"; cat $ERRLOG; echo "</pre>") | /usr/sbin/sendmail $MAILTO ; [ $STATUS -eq 0 ] && ( echo ${SUBJECT_OK}; echo $MIME; echo $CONTENTTYPE; echo  $CONTENTDISPO;  echo -e "<pre>Finished running the application $EXECUTABLE on " `hostname` "\ncheck log file $LOG\n</pre>") | /usr/sbin/sendmail $MAILTO ;
 
 
 

--- a/Victor/dq2.victor.cms/config/dq2/etc/post_install.sh
+++ b/Victor/dq2.victor.cms/config/dq2/etc/post_install.sh
@@ -15,5 +15,7 @@ echo "EMAIL notification address is ${DASHB_NOTIFICATION}"
 #useradd --shell /bin/bash --create-home --home-dir /home/cern cern
 #/usr/sbin/useraddcern cmspopdb
 
+sed -i "s@cmspopdb@$DASHBUSER@" /etc/cron.d/victor.agent.cms
+
 changeOwner /opt/dq2/etc/dq2.cfg
 changeOwner /opt/dq2/etc/logging.cfg


### PR DESCRIPTION
Hi all,

this pull request fixes issue #11 . It changes the user which runs the cron-job for the victor agent from root to cmspopdb. This user is configurable via the $DASHBUSER variable.
It might be useful to specify a common variable, which sets the user, for all configurations. Currently some configurations use the $POPDBUSER variable (xrootd and crab) and others use the $DASHBUSER variable (victor agent, popdb.web and popdb.cmssw).

Please feel free to comment.

Cheers, Rene
